### PR TITLE
update version number to 1.0.0 to comply with valid semantic versioning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
 	"name": "adapt-html",
 	"description": "A component containing custom HTML and CSS",
-	"version": "1.0",
+	"version": "1.0.0",
 	"framework": "^2.0.0",
 	"displayName": "HTML",
 	"component": "html",


### PR DESCRIPTION
the current version number `1.0` breaks tools like adapt-setup which requires a valid semantic versioning in the format of `major.minor.patch`.